### PR TITLE
Build dammit

### DIFF
--- a/packages/webmaster/webmaster.42/opam
+++ b/packages/webmaster/webmaster.42/opam
@@ -7,4 +7,5 @@ build: [
 depends: [
   "assemblage"
   "uri"
+  "ocamlnet"
 ]


### PR DESCRIPTION
The `install-META` target of camlp4 doesn't seem to exist and it installs the findlib package anyway. Also, webmaster depends on ocamlnet for sloppy HTML parsing.
