### PR TITLE
+ocamlary

### DIFF
--- a/packages/ocamlary-test-library/ocamlary-test-library.0.0.0/descr
+++ b/packages/ocamlary-test-library/ocamlary-test-library.0.0.0/descr
@@ -1,0 +1,1 @@
+A library package to test ocamlary's documentation rendering

--- a/packages/ocamlary-test-library/ocamlary-test-library.0.0.0/findlib
+++ b/packages/ocamlary-test-library/ocamlary-test-library.0.0.0/findlib
@@ -1,0 +1,1 @@
+ocamlary-test-library

--- a/packages/ocamlary-test-library/ocamlary-test-library.0.0.0/opam
+++ b/packages/ocamlary-test-library/ocamlary-test-library.0.0.0/opam
@@ -1,0 +1,6 @@
+opam-version: "1"
+maintainer: "David Sheets <sheets@alum.mit.edu>"
+authors: "David Sheets <sheets@alum.mit.edu>"
+build: [
+  [make]
+]

--- a/packages/ocamlary-test-library/ocamlary-test-library.0.0.0/url
+++ b/packages/ocamlary-test-library/ocamlary-test-library.0.0.0/url
@@ -1,0 +1,1 @@
+git: "https://github.com/dsheets/ocamlary-test-library.git"

--- a/packages/ocamlary/ocamlary.0.0.0/findlib
+++ b/packages/ocamlary/ocamlary.0.0.0/findlib
@@ -1,0 +1,1 @@
+ocamlary

--- a/packages/ocamlary/ocamlary.0.0.0/opam
+++ b/packages/ocamlary/ocamlary.0.0.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1"
+build: [
+  ["assemblage" "setup"]
+  [make]
+  [make "install"]
+]
+depends: [
+  "assemblage"
+  "opam-lib"
+  "opam-units"
+  "opam-doc-base"
+  "cow"
+]

--- a/packages/ocamlary/ocamlary.0.0.0/url
+++ b/packages/ocamlary/ocamlary.0.0.0/url
@@ -1,0 +1,1 @@
+git: "https://github.com/dsheets/ocamlary.git"


### PR DESCRIPTION
I get:

``` sh
$ opam install ocamlary
The following actions will be performed:
 - install   ocamlary.0.0.0
=== 1 to install ===

=-=- Synchronizing package archives -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[ocamlary.0.0.0] Fetching https://github.com/dsheets/ocamlary.git

=-=- Installing packages =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=


#=== ERROR while installing ocamlary.0.0.0 ====================================#
Internal error:
  /home/dsheets/.opam/packages.dev/ocamlary.0.0.0/assemble.ml is not a valid tar archive.
```

and I don't know why. Does it work for you? Might be my config... I'll keep debugging it.
