### PR TITLE
Add base-no-ppx virtual package that admits 4.02.1+doc

### DIFF
--- a/packages/base-no-ppx/base-no-ppx.base/descr
+++ b/packages/base-no-ppx/base-no-ppx.base/descr
@@ -1,0 +1,1 @@
+A pseudo-library to indicate lack of extension points support

--- a/packages/base-no-ppx/base-no-ppx.base/opam
+++ b/packages/base-no-ppx/base-no-ppx.base/opam
@@ -1,0 +1,3 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+available: [ compiler < "4.02.0" | compiler = "4.02.1+doc" ]


### PR DESCRIPTION
`4.02.1+doc` breaks ppx interface by adding new variant `PDoc` and record field `documentation`.

`base-no-ppx` is required for lwt >2.4.5 which depends on either `base-no-ppx` or `ppx_tools`.